### PR TITLE
Error picking mysql as database (typo on config.py)

### DIFF
--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/config.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/config.py
@@ -97,7 +97,7 @@ CELERY_BEAT_SCHEDULE = {
 # ========
 {% if cookiecutter.database == 'postgresql'%}
 SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://{{cookiecutter.project_shortname}}:{{cookiecutter.project_shortname}}@localhost/{{cookiecutter.project_shortname}}'
-{% elif cookiecuteter.database == 'mysql'%}
+{% elif cookiecutter.database == 'mysql'%}
 SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://{{cookiecutter.project_shortname}}:{{cookiecutter.project_shortname}}@localhost/{{cookiecutter.project_shortname}}'
 {% else %}
 SQLALCHEMY_DATABASE_URI = 'sqlite:///{{cookiecutter.project_shortname}}.db'


### PR DESCRIPTION
Error picking mysql as database

```
transifex_project [my-site]: 
Select database:
1 - postgresql
2 - mysql
Choose from 1, 2 [1]: 2
Select elasticsearch:
1 - elasticsearch6
2 - elasticsearch5
Choose from 1, 2 [1]: 
Unable to create file '{{cookiecutter.package_name}}/config.py'
Error message: 'cookiecuteter' is undefined
```