### PR TITLE
global: add info how to generate requirements.txt

### DIFF
--- a/{{cookiecutter.project_shortname}}/.travis.yml
+++ b/{{cookiecutter.project_shortname}}/.travis.yml
@@ -48,7 +48,6 @@ before_install:
   - "travis_retry pip install twine wheel coveralls requirements-builder"
   - "requirements-builder -e all --level=min setup.py > .travis-lowest-requirements.txt"
   - "requirements-builder -e all --level=pypi setup.py > .travis-release-requirements.txt"
-  - "requirements-builder -e all --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt"
   - "./scripts/setup-npm.sh"
 
 install:

--- a/{{cookiecutter.project_shortname}}/requirements-devel.txt
+++ b/{{cookiecutter.project_shortname}}/requirements-devel.txt
@@ -1,1 +1,0 @@
-{% include 'misc/header.py' -%}

--- a/{{cookiecutter.project_shortname}}/requirements.txt
+++ b/{{cookiecutter.project_shortname}}/requirements.txt
@@ -1,1 +1,10 @@
 {% include 'misc/header.py' -%}
+# This file will include pinned versions of packages
+# TODO: Generate this file by running the following commands:
+#
+# pip install -e .[all]
+# pip install pip-tools
+# pip-compile
+#
+# You can read more about pip-compile command here:
+# https://github.com/jazzband/pip-tools#example-usage-for-pip-compile


### PR DESCRIPTION
* Adds instruction how to generate the requirements.txt file from
  setup.py (closes #4).

* Removes the requirements-devel.txt, as it doesn't feel very useful
  for now.

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>