### PR TITLE
tests: fix pytest.ini config

### DIFF
--- a/{{cookiecutter.project_shortname}}/pytest.ini
+++ b/{{cookiecutter.project_shortname}}/pytest.ini
@@ -2,4 +2,4 @@
 [pytest]
 pep8ignore = docs/conf.py ALL
 addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov={{ cookiecutter.package_name }} --cov-report=term-missing --ignore=setup.py
-testpaths = docs tests/unit {{ cookiecutter.package_name }}
+testpaths = docs tests {{ cookiecutter.package_name }}


### PR DESCRIPTION
* Fixes pytest.ini configuration (closes #22).

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>