### PR TITLE
config: set secure defaults

### DIFF
--- a/{{cookiecutter.project_shortname}}/scripts/server
+++ b/{{cookiecutter.project_shortname}}/scripts/server
@@ -2,6 +2,6 @@
 {% include 'misc/header.py' %}
 set -e
 
-export FLASK_DEBUG=1
-
-invenio run
+script_path=$(dirname "$0")
+invenio run --cert "$script_path"/../docker/nginx/test.crt \
+            --key "$script_path"/../docker/nginx/test.key \

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/config.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/config.py
@@ -115,14 +115,17 @@ JSONSCHEMAS_HOST = '{{cookiecutter.project_shortname}}.com'
 # http://flask.pocoo.org/docs/0.12/config/#builtin-configuration-values
 
 #: Secret key - each installation (dev, production, ...) needs a separate key.
+#: It should be changed before deploying.
 SECRET_KEY = 'CHANGE_ME'
 #: Max upload size for form data via application/mulitpart-formdata.
 MAX_CONTENT_LENGTH = 100 * 1024 * 1024  # 100 MiB
-
-# REST
-# ====
-#: Enable Cross-Origin Resource Sharing support.
-REST_ENABLE_CORS = True
+#: Sets cookie with the secure flag by default
+SESSION_COOKIE_SECURE = True
+#: Since HAProxy and Nginx route all requests no matter the host header
+#: provided, the allowed hosts variable is set to localhost. In production it
+#: should be set to the correct host and it is strongly recommended to only
+#: route correct hosts to the application.
+APP_ALLOWED_HOSTS = ['localhost']
 
 # Debug
 # =====


### PR DESCRIPTION
* Runs the application always on HTTPS.

* CORS off by default.

* Sets allowed hosts to localhost since HAProxy and Nginx pass all request
  regardless the host header (closes #19).