### PR TITLE
haproxy: remove /ping from health check

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/haproxy/haproxy.cfg
+++ b/{{cookiecutter.project_shortname}}/docker/haproxy/haproxy.cfg
@@ -44,7 +44,7 @@ backend ssl_app
   http-check disable-on-404
   option http-server-close
   option forwardfor except 127.0.0.0/8
-  option httpchk HEAD /ping HTTP/1.0
+  option httpchk HEAD / HTTP/1.0
   server web1 frontend:443 check check-ssl fall 2 inter 20000 maxconn 30 rise 1 ssl verify none weight 2
 
 backend ssl_static
@@ -52,5 +52,5 @@ backend ssl_static
   http-check disable-on-404
   option http-server-close
   option forwardfor except 127.0.0.0/8
-  option httpchk HEAD /ping HTTP/1.0
+  option httpchk HEAD / HTTP/1.0
   server web1 frontend:443 check check-ssl fall 2 inter 5000 maxconn 255 rise 1 ssl verify none weight 2


### PR DESCRIPTION
* Changes the destination for the httpchk from /ping to /,
  as the ping endpoint was removed.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>
Co-Authored-by: Christos Topaloudis <mr.topless@cern.ch>