### PR TITLE
docker: nginx request tracing

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
@@ -76,8 +76,8 @@ server {
     uwsgi_param X-Request-ID $request_id;
     # X-Session-ID / X-User-ID is read by nginx and included in the logs,
     # however we don't want to expose them to clients so we are hiding them.
-    uwsgi_hide_header X-Session-ID
-    uwsgi_hide_header X-User-ID
+    uwsgi_hide_header X-Session-ID;
+    uwsgi_hide_header X-User-ID;
     # Max upload size (except for files) is set to 100mb as default.
     client_max_body_size 100m;
   }
@@ -93,8 +93,8 @@ server {
     uwsgi_param X-Request-ID $request_id;
     # X-Session-ID / X-User-ID is read by nginx and included in the logs,
     # however we don't want to expose them to clients so we are hiding them.
-    uwsgi_hide_header X-Session-ID
-    uwsgi_hide_header X-User-ID
+    uwsgi_hide_header X-Session-ID;
+    uwsgi_hide_header X-User-ID;
     # Max upload size (except for files) is set to 100mb as default.
     client_max_body_size 100m;
   }
@@ -110,8 +110,8 @@ server {
     uwsgi_param X-Request-ID $request_id;
     # X-Session-ID / X-User-ID is read by nginx and included in the logs,
     # however we don't want to expose them to clients so we are hiding them.
-    uwsgi_hide_header X-Session-ID
-    uwsgi_hide_header X-User-ID
+    uwsgi_hide_header X-Session-ID;
+    uwsgi_hide_header X-User-ID;
     # Max upload size for files is set to 50GB (configure as needed).
     client_max_body_size 50G;
   }

--- a/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
@@ -49,6 +49,10 @@ server {
 
   add_header Strict-Transport-Security "max-age=15768000"; # 6 months
 
+  # Request ID tracing (allows end-to-end tracking of requests for better
+  # troubleshooting)
+  add_header X-Request-ID $request_id;
+
   # The request body is sent to the proxied server immediately as it is
   # received
   proxy_request_buffering off;
@@ -68,6 +72,12 @@ server {
     uwsgi_param Host $host;
     uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
     uwsgi_param X-Forwarded-Proto $scheme;
+    # Pass request id to the ui server
+    uwsgi_param X-Request-ID $request_id;
+    # X-Session-ID / X-User-ID is read by nginx and included in the logs,
+    # however we don't want to expose them to clients so we are hiding them.
+    uwsgi_hide_header X-Session-ID
+    uwsgi_hide_header X-User-ID
     # Max upload size (except for files) is set to 100mb as default.
     client_max_body_size 100m;
   }
@@ -79,6 +89,12 @@ server {
     uwsgi_param Host $host;
     uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
     uwsgi_param X-Forwarded-Proto $scheme;
+    # Pass request id to the api server
+    uwsgi_param X-Request-ID $request_id;
+    # X-Session-ID / X-User-ID is read by nginx and included in the logs,
+    # however we don't want to expose them to clients so we are hiding them.
+    uwsgi_hide_header X-Session-ID
+    uwsgi_hide_header X-User-ID
     # Max upload size (except for files) is set to 100mb as default.
     client_max_body_size 100m;
   }
@@ -90,6 +106,12 @@ server {
     uwsgi_param Host $host;
     uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
     uwsgi_param X-Forwarded-Proto $scheme;
+    # Pass request id to api server
+    uwsgi_param X-Request-ID $request_id;
+    # X-Session-ID / X-User-ID is read by nginx and included in the logs,
+    # however we don't want to expose them to clients so we are hiding them.
+    uwsgi_hide_header X-Session-ID
+    uwsgi_hide_header X-User-ID
     # Max upload size for files is set to 50GB (configure as needed).
     client_max_body_size 50G;
   }

--- a/{{cookiecutter.project_shortname}}/docker/nginx/nginx.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/nginx.conf
@@ -13,11 +13,20 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    # Standard log format
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    # Request tracing log format - includes request id, session id, user id,
+    # and request timing.
+    log_format trace '$remote_addr - [$time_local] "$request" '
+                 '$status  $body_bytes_sent "$http_referer"  '
+                 '"$http_user_agent" "$http_x_forwarded_for" $request_id '
+                 '$msec $request_time '
+                 '$upstream_http_x_session_id $upstream_http_x_user_id';
+
+    access_log  /var/log/nginx/access.log  trace;
 
     sendfile        on;
     tcp_nopush      on;


### PR DESCRIPTION
With this PR, nginx will be configured to generate a request id (uuid) for each incoming request and pass it to the upstream WSGI server. The request id will also be exposed sent back to the client in the ``X-Request-ID`` header.

In addition the upstream can send to headers ``X-Session-ID`` and ``X-User-ID`` in the response which will be removed by nginx before being sent to the client. The values can however be used to log in the access log.

This means that NGINX can log: request-id, session-id and user-id for each request. This will allow 1) to correlate errors (in e.g. sentry) with specific http requests and 2) trace requests for specific users to troubleshoot problems faster.

This PR depends on:
- inveniosoftware/invenio-app#38
- inveniosoftware/invenio-logging#41
- inveniosoftware/invenio-accounts#274

And, the PR needs proper testing and some documentation on impact on privacy and that you should ensure that log files are automatically deleted after a retention period.