### PR TITLE
mappings: change PID and role to keyword

### DIFF
--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/mappings/v{{cookiecutter.elasticsearch}}/records/record-v1.0.0.json
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/mappings/v{{cookiecutter.elasticsearch}}/records/record-v1.0.0.json
@@ -16,7 +16,7 @@
           "type": "completion"
         },
         "{{ cookiecutter.datamodel_pid_name }}": {
-          "type": "double"
+          "type": "keyword"
         },
         "keywords": {
           "type": "keyword"
@@ -43,7 +43,7 @@
               "type": "text"
             },
             "role": {
-              "type": "text"
+              "type": "keyword"
             },
             "email": {
               "type": "text"


### PR DESCRIPTION
* Closes https://github.com/inveniosoftware/cookiecutter-invenio-datamodel/issues/43 and https://github.com/inveniosoftware/cookiecutter-invenio-datamodel/pull/46 (old PR in cookiecutter-datamodel)
* Tested with a cookiecutter instance (v3.1). Added 13 documents and checked that queries such as ``?q=id:1`` gave as a result only the document with id 1 and not 1,10,11,11, etc. Same for 2 and 12, 3 and 13.