### PR TITLE
installation: remove debugtool from entry point

### DIFF
--- a/{{cookiecutter.project_shortname}}/setup.py
+++ b/{{cookiecutter.project_shortname}}/setup.py
@@ -37,7 +37,6 @@ setup(
             '{{ cookiecutter.project_shortname }} = invenio_app.cli:cli',
         ],
         'invenio_base.apps': [
-            'flask_debugtoolbar = flask_debugtoolbar:DebugToolbarExtension',
             {%- if cookiecutter.datamodel == 'Custom' %}
             '{{ cookiecutter.package_name }}_records = {{ cookiecutter.package_name }}.records:{{ cookiecutter.datamodel_extension_class }}',
             {%- endif %}


### PR DESCRIPTION
* Removes Flask Debugtoolbar from the entry point registration in
  favor of having Invenio-App register the toolbar in case it is
  installed.