### PR TITLE
docs: inlcude LICENSE file as literal

### DIFF
--- a/{{cookiecutter.project_shortname}}/docs/license.rst
+++ b/{{cookiecutter.project_shortname}}/docs/license.rst
@@ -1,7 +1,7 @@
 License
 =======
 
-.. include:: ../LICENSE
+.. literalinclude:: ../LICENSE
 
 .. note::
     In applying this license, CERN does not waive the privileges and immunities


### PR DESCRIPTION
* Sometimes the LICENSE file can include a sequence of characters which
  might be considered by Sphinx as a scape sequence, better to include
  it as is.