### PR TITLE
Create and connect files volumes to containers

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -43,7 +43,7 @@ services:
       file: docker-services.yml
       service: frontend
     volumes:
-      - static_data:/opt/invenio/var/instance/static
+      - static_data:/opt/invenio/var/instance/static:ro
     links:
       - web-ui
       - web-api
@@ -75,7 +75,6 @@ services:
     ports:
       - "5000"
     volumes:
-      - static_data:/opt/invenio/var/instance/static
       - uploaded_data:/opt/invenio/var/instance/data
       - archived_data:/opt/invenio/var/instance/archive
     links:
@@ -97,7 +96,6 @@ services:
       - mq
       - db
     volumes:
-      - static_data:/opt/invenio/var/instance/static
       - uploaded_data:/opt/invenio/var/instance/data
       - archived_data:/opt/invenio/var/instance/archive
   # Monitoring of Celery

--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -58,6 +58,8 @@ services:
       - "5000"
     volumes:
       - static_data:/opt/invenio/var/instance/static
+      - uploaded_data:/opt/invenio/var/instance/data
+      - archived_data:/opt/invenio/var/instance/archive
     links:
       - cache
       - es
@@ -74,6 +76,8 @@ services:
       - "5000"
     volumes:
       - static_data:/opt/invenio/var/instance/static
+      - uploaded_data:/opt/invenio/var/instance/data
+      - archived_data:/opt/invenio/var/instance/archive
     links:
       - cache
       - es
@@ -92,6 +96,10 @@ services:
       - es
       - mq
       - db
+    volumes:
+      - static_data:/opt/invenio/var/instance/static
+      - uploaded_data:/opt/invenio/var/instance/data
+      - archived_data:/opt/invenio/var/instance/archive
   # Monitoring of Celery
   # http://127.0.0.1:5555
   flower:
@@ -128,3 +136,5 @@ services:
       service: es
 volumes:
   static_data:
+  uploaded_data:
+  archived_data:


### PR DESCRIPTION
The UI, API and worker containers need to access the files volume. For instance, uploaded files are ingested through the API container but downloaded through the UI container.

See also the pull request on docker-invenio creating the mountpoints so that permissions are correct.