### PR TITLE
records: list of files and preview

### DIFF
--- a/{{cookiecutter.project_shortname}}/tests/api/test_api_record_files.py
+++ b/{{cookiecutter.project_shortname}}/tests/api/test_api_record_files.py
@@ -49,19 +49,20 @@ def _get_record(client, pid_value):
 def test_record_creation(client, location):
     """Test create record using REST API."""
     pid_value, rec = _create_record(client)
-    assert rec["_bucket"]
-    assert "_files" not in rec
+    assert "_bucket" not in rec
+    assert "files" not in rec
+    assert "$schema" not in rec['metadata']
 
     # retrieve record
     rec = _get_record(client, pid_value)
-    assert rec["_bucket"]
-    assert "_files" not in rec
+    assert "_bucket" not in rec
+    assert "files" not in rec
+    assert "$schema" not in rec['metadata']
 
 
 def test_files_creation_deletion(client, location):
     """Test that files are in record metadata."""
-    pid_value, rec = _create_record(client)
-    bucket_id = rec["_bucket"]
+    pid_value, _ = _create_record(client)
 
     # add a file
     headers = [("Content-Type", "application/octet-stream")]
@@ -72,9 +73,9 @@ def test_files_creation_deletion(client, location):
 
     # retrieve record and files
     rec = _get_record(client, pid_value)
-    assert rec["_bucket"] == bucket_id
-    assert rec["_files"]
-    first_file = rec["_files"][0]
+    assert "_bucket" not in rec
+    assert "files" in rec
+    first_file = rec["files"][0]
     first_file["key"] = "test.jpg"
 
     # Check if the files link is present
@@ -89,5 +90,5 @@ def test_files_creation_deletion(client, location):
 
     # retrieve record and files
     rec = _get_record(client, pid_value)
-    assert rec["_bucket"] == bucket_id
-    assert rec["_files"] == []
+    assert "_bucket" not in rec
+    assert rec["files"] == []

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/config.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/config.py
@@ -139,3 +139,16 @@ RECORDS_FILES_REST_ENDPOINTS = {
 FILES_REST_PERMISSION_FACTORY = \
     '{{ cookiecutter.package_name }}.records.permissions:files_permission_factory'
 """Files-REST permissions factory."""
+
+PREVIEWER_PREFERENCE = [
+    'csv_dthreejs',
+    'iiif_image',
+    'simple_image',
+    'json_prismjs',
+    'xml_prismjs',
+    'mistune',
+    'pdfjs',
+    'ipynb',
+    'zip',
+]
+"""IIIF previewer preferences."""

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/marshmallow/json.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/marshmallow/json.py
@@ -17,6 +17,7 @@ def bucket_from_context(_, context):
     record = (context or {}).get('record', {})
     return record.get('_bucket', missing)
 
+
 def files_from_context(_, context):
     """Get the record's files from context."""
     record = (context or {}).get('record', {})
@@ -63,13 +64,10 @@ class MetadataSchemaV1(StrictKeysMixin):
     keywords = fields.List(SanitizedUnicode(), many=True)
     publication_date = DateString()
     contributors = Nested(ContributorSchemaV1, many=True, required=True)
-    _bucket = GenFunction(deserialize=bucket_from_context, load_only=True)
-    _files = GenFunction(deserialize=files_from_context, load_only=True)
     _schema = GenFunction(
         attribute="$schema",
         data_key="$schema",
-        deserialize=schema_from_context,
-        serialize=schema_from_context,
+        deserialize=schema_from_context,  # to be added only when loading
     )
 
 
@@ -82,7 +80,5 @@ class RecordSchemaV1(StrictKeysMixin):
     updated = fields.Str(dump_only=True)
     links = fields.Dict(dump_only=True)
     id = PersistentIdentifier()
-    _bucket = GenFunction(
-        serialize=bucket_from_context, deserialize=bucket_from_context)
-    _files = GenFunction(
+    files = GenFunction(
         serialize=files_from_context, deserialize=files_from_context)

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/marshmallow/json.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/marshmallow/json.py
@@ -17,6 +17,11 @@ def bucket_from_context(_, context):
     record = (context or {}).get('record', {})
     return record.get('_bucket', missing)
 
+def files_from_context(_, context):
+    """Get the record's files from context."""
+    record = (context or {}).get('record', {})
+    return record.get('_files', missing)
+
 
 def files_from_context(_, context):
     """Get the record's files from context."""

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/tasks.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/tasks.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, print_function
 
+import sqlalchemy
 from celery import shared_task
 from invenio_db import db
 from invenio_records_files.api import Record
@@ -15,15 +16,18 @@ def update_record_files_by_bucket(bucket_id):
     record_bucket = \
         RecordsBuckets.query.filter_by(bucket_id=bucket_id).first()
     if record_bucket:
-        record = Record.get_record(record_bucket.record_id)
-        record.files.flush()
-        record.commit()
-        # it might fail with `sqlalchemy.orm.exc.StaleDataError`
-        # if another task is updating the record at the same time.
-        # The exception might be ignored because one of the task will
-        # anyway update the record metadata with the entire content
-        # of the bucket.
-        db.session.commit()
+        try:
+            record = Record.get_record(record_bucket.record_id)
+            record.files.flush()
+            record.commit()
+            db.session.commit()
+        except sqlalchemy.orm.exc.StaleDataError:
+            # it might fail with `sqlalchemy.orm.exc.StaleDataError`
+            # if another task is updating the record at the same time.
+            # The exception might be ignored because one of the task will
+            # anyway update the record metadata with the entire content
+            # of the bucket.
+            pass
 
 
 def update_record_files_async(object_version):

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/templates/records/record.html
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/templates/records/record.html
@@ -2,7 +2,8 @@
 {%- extends config.RECORDS_UI_BASE_TEMPLATE %}
 
 {%- macro record_content(data) %}
-  {% for key, value in data.items() recursive %}
+  {% set ignore_list = ['_bucket', '$schema'] %}
+  {% for key, value in data.items() if key not in ignore_list recursive %}
     <li class="list-group-item">
     {% if value is mapping %}
         <strong>{{ key }}:</strong>

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/templates/records/record.html
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/templates/records/record.html
@@ -29,14 +29,65 @@
   {% endfor %}
 {%- endmacro %}
 
-{%- block page_body %}
-<div class="container">
-  <h2>{{record.title}}</h2>
-  <div class="panel panel-default">
-    <ul class="list-group">
-      {{ record_content(record) }}
-    </ul>
+{%- macro file_list(files) -%}
+  <div class="panel files-box" id="files">
+    <div class="panel-heading">
+      <a class="panel-toggle" data-toggle="collapse" href="#collapseTwo">
+        {{ _("Files") }}
+        <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
+        <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
+      </a>
+      <small class="text-muted">{% if files %} ({{files|sum(attribute='file.size')|filesizeformat}}){% endif %}</small>
+    </div>
+    <div class="collapse in" id="collapseTwo">
+      <table class="table table-striped" >
+        <thead>
+          <tr class="">
+            <th>{{_('Name')}}</th>
+            <th>{{_('Size')}}</th>
+          </tr>
+        </thead>
+        <tbody>
+        {%- for file in files|sort(attribute='key') -%}
+        {%- set file_url = url_for('invenio_records_ui.recid_files', pid_value=pid.pid_value, filename=file.key, download=1) %}
+          <tr>
+            <td>
+              <a class="filename" href="{{file_url}}">{{ file.key }}</a>
+              <br/><small class="text-muted nowrap">{{file.file.checksum}} <i class="fa fa-question-circle text-muted" data-toggle="tooltip" tooltip data-placement="top" title="{{_('This is the file fingerprint (MD5 checksum), which can be used to verify the file integrity.')}}"></i></small>
+            </td>
+            <td class="nowrap">{{ file.file.size|filesizeformat }}</td>
+            <td class="nowrap">
+              <span class="pull-right">
+                {% if file.type is previewable %} {# Where does this come from? #}
+                  <button class="btn preview-link btn-xs btn-default" data-filename="{{file.key}}">
+                    <i class="fa fa-eye"></i> {{_("Preview")}}
+                  </button>
+                {% endif %}
+                <a class="btn btn-xs btn-default" href="{{file_url}}">
+                  <i class="fa fa-download"></i> {{_("Download")}}
+                </a>
+              </span>
+            </td>
+          </tr>
+        {%- endfor -%}
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
+{%- endmacro %}
+
+{%- block page_body %}
+  <div class="container">
+    <h2>{{record.title}}</h2>
+    <div class="panel panel-default">
+      <ul class="list-group">
+        {{ record_content(record) }}
+      </ul>
+    </div>
+    {% set files = record._files %}
+    {%- if files -%}
+      {{ file_list(files) }}
+    {%- endif %}
+  </div>
 {%- endblock %}
 {% endraw %}

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/templates/records/record.html
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/templates/records/record.html
@@ -32,14 +32,14 @@
 {%- macro file_list(files) -%}
   <div class="panel files-box" id="files">
     <div class="panel-heading">
-      <a class="panel-toggle" data-toggle="collapse" href="#collapseTwo">
+      <a class="panel-toggle" data-toggle="collapse" href="#collapsableFiles">
         {{ _("Files") }}
         <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
         <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
       </a>
-      <small class="text-muted">{% if files %} ({{files|sum(attribute='file.size')|filesizeformat}}){% endif %}</small>
+      <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat}}){% endif %}</small>
     </div>
-    <div class="collapse in" id="collapseTwo">
+    <div class="collapse in" id="collapsableFiles">
       <table class="table table-striped" >
         <thead>
           <tr class="">
@@ -49,21 +49,23 @@
         </thead>
         <tbody>
         {%- for file in files|sort(attribute='key') -%}
-        {%- set file_url = url_for('invenio_records_ui.recid_files', pid_value=pid.pid_value, filename=file.key, download=1) %}
+        {%- set file_url_download = url_for('invenio_records_ui.recid_files', pid_value=pid.pid_value, filename=file.key, download=1) %}
+        {%- set file_url_preview = url_for('invenio_records_ui.recid_preview', pid_value=pid.pid_value, filename=file.key) %}
           <tr>
             <td>
-              <a class="filename" href="{{file_url}}">{{ file.key }}</a>
-              <br/><small class="text-muted nowrap">{{file.file.checksum}} <i class="fa fa-question-circle text-muted" data-toggle="tooltip" tooltip data-placement="top" title="{{_('This is the file fingerprint (MD5 checksum), which can be used to verify the file integrity.')}}"></i></small>
+              <a class="filename preview-link" href="#preview" data-url="{{file_url_preview}}">{{ file.key }}</a>
+              <br/><small class="text-muted nowrap">{{file.checksum}} <i class="fa fa-question-circle text-muted" data-toggle="tooltip" tooltip data-placement="top" title="{{_('This is the file fingerprint (MD5 checksum), which can be used to verify the file integrity.')}}"></i></small>
             </td>
-            <td class="nowrap">{{ file.file.size|filesizeformat }}</td>
+            <td class="nowrap">{{ file.size|filesizeformat }}</td>
             <td class="nowrap">
               <span class="pull-right">
-                {% if file.type is previewable %} {# Where does this come from? #}
-                  <button class="btn preview-link btn-xs btn-default" data-filename="{{file.key}}">
+                {% set file_type = file.key.split('.')[-1] %}
+                {% if file_type is previewable %}
+                  <button class="btn preview-link btn-xs btn-default" data-url="{{file_url_preview}}">
                     <i class="fa fa-eye"></i> {{_("Preview")}}
                   </button>
                 {% endif %}
-                <a class="btn btn-xs btn-default" href="{{file_url}}">
+                <a class="btn btn-xs btn-default" href="{{file_url_download}}">
                   <i class="fa fa-download"></i> {{_("Download")}}
                 </a>
               </span>
@@ -76,6 +78,36 @@
   </div>
 {%- endmacro %}
 
+
+{% macro preview(files) %}
+  {% set selected_file = files|select_preview_file %}
+  {%- if selected_file -%}
+    <div class="panel" id="preview">
+      <div class="panel-heading">
+        <a class="panel-toggle" data-toggle="collapse" href="#collapsablePreview">
+          {{_('Preview')}}
+          <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
+          <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
+        </a>
+      </div>
+      <div id="collapsablePreview" class="collapse in">
+        {{- preview_file('invenio_records_ui.recid_preview', pid=pid, filename=selected_file.key) }}
+      </div>
+    </div>
+  {%- endif %}
+{%- endmacro %}
+
+
+{%- macro preview_file(preview_endpoint, pid, filename, id='preview-iframe', width='100%', height='400') %}
+  <iframe
+   class="preview-iframe"
+   id="{{id}}"
+   width="{{width}}"
+   height="{{height}}"
+   src="{{ url_for(preview_endpoint, pid_value=pid.pid_value, filename=filename) }}"></iframe>
+{%- endmacro %}
+
+
 {%- block page_body %}
   <div class="container">
     <h2>{{record.title}}</h2>
@@ -85,9 +117,11 @@
       </ul>
     </div>
     {% set files = record._files %}
+    {{ preview(files) }}
     {%- if files -%}
       {{ file_list(files) }}
     {%- endif %}
   </div>
+  {{ webpack['{%- endraw %}{{cookiecutter.project_shortname}}{%- raw %}-preview.js'] }}
 {%- endblock %}
 {% endraw %}

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/views.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/views.py
@@ -3,7 +3,11 @@
 
 from __future__ import absolute_import, print_function
 
+from operator import itemgetter
+from os.path import splitext
+
 from flask import Blueprint
+from invenio_previewer.proxies import current_previewer
 
 blueprint = Blueprint(
     '{{ cookiecutter.package_name}}_records',
@@ -17,3 +21,24 @@ The sole purpose of this blueprint is to ensure that Invenio can find the
 templates and static files located in the folders of the same names next to
 this file.
 """
+
+
+#
+# Files related template filters.
+#
+@blueprint.app_template_filter()
+def select_preview_file(files):
+    """Get list of files and select one for preview."""
+    selected = None
+
+    try:
+        for f in sorted(files or [], key=itemgetter('key')):
+            file_type = splitext(f['key'])[1][1:].lower()
+            if file_type in current_previewer.previewable_extensions:
+                if selected is None:
+                    selected = f
+                elif f['default']:
+                    selected = f
+    except KeyError:
+        pass
+    return selected

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/assets/js/{{cookiecutter.package_name}}/previewer.js
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/assets/js/{{cookiecutter.package_name}}/previewer.js
@@ -1,0 +1,8 @@
+import $ from "jquery";
+
+$("#files")
+  .find(".preview-link")
+  .on("click", function(event) {
+    $("#preview").show();
+    $("#preview-iframe").attr("src", $(event.target).data("url"));
+  });

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/assets/scss/{{cookiecutter.package_name}}/theme.scss
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/assets/scss/{{cookiecutter.package_name}}/theme.scss
@@ -3,3 +3,19 @@
 // Check out https://github.com/inveniosoftware/invenio-theme/blob/master/invenio_theme/assets/scss/invenio_theme
 @import "variables";
 @import "../invenio_theme/styles";
+
+
+.hide-on-collapsed {
+	display: block;
+}
+.show-on-collapsed {
+	display: none;
+}
+.panel-toggle.collapsed {
+	.hide-on-collapsed {
+		display: none;
+	}
+	.show-on-collapsed {
+		display: block;
+	}
+}

--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/webpack.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/webpack.py
@@ -10,6 +10,7 @@ theme = WebpackBundle(
     'assets',
     entry={
         '{{ cookiecutter.project_shortname }}-theme': './scss/{{ cookiecutter.package_name }}/theme.scss',
+        '{{ cookiecutter.project_shortname }}-preview': './js/{{ cookiecutter.package_name }}/previewer.js',
     },
     dependencies={
         # add any additional npm dependencies here...


### PR DESCRIPTION
Closes #173

Currently depends on https://github.com/inveniosoftware/invenio-records-files/compare/master...mvidalgarcia:add-files to work. Waiting for proper `_files` integration.

When displaying PDFs, some warnings/errors show up:
![image](https://user-images.githubusercontent.com/8863238/69132665-ce509500-0ab4-11ea-9cc7-295060d7cb9f.png)
