### PR TITLE
installation: bump Invenio to v3.3

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,7 @@
     "year": "{% now 'local', '%Y' %}",
     "copyright_holder": "{{ cookiecutter.author_name }}",
     "transifex_project": "{{ cookiecutter.project_shortname }}",
+    "python_version": ["3.7", "3.6"],
     "database": ["postgresql", "mysql", "sqlite"],
     "elasticsearch": ["7", "6"],
     "datamodel": ["Custom", "None"],

--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -6,8 +6,7 @@ name = "pypi"
 [packages]
 Babel = ">=2.4.0"
 Flask-BabelEx = ">=0.9.3"
-invenio = { version = ">=3.2.0,<3.3.0", extras = ["base", "auth", "metadata", "files", "{{ cookiecutter.database }}", "elasticsearch{{ cookiecutter.elasticsearch }}" ]}
-lxml = ">=3.5.0,<4.2.6"
+invenio = { version = ">=3.3.0,<3.4.0", extras = ["base", "auth", "metadata", "files", "{{ cookiecutter.database }}", "elasticsearch{{ cookiecutter.elasticsearch }}" ]}
 marshmallow = ">=3.0.0,<4.0.0"
 uwsgi = ">=2.0"
 uwsgi-tools = ">=1.1.1"
@@ -30,7 +29,7 @@ pytest-runner = ">=3.0.0,<5"
 Sphinx = ">=1.5.1"
 
 [requires]
-python_version = "3.6"
+python_version = "{{cookiecutter.python_version}}"
 
 [scripts]
 test = "python setup.py test"


### PR DESCRIPTION
* Use latest Invenio release (closes #219).

* Includes new configuration to allow choosing different Python
  versions (closes inveniosoftware/invenio#4012).