### PR TITLE
semantic: apply overrides to message component

### DIFF
--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/assets/semantic-ui/less/{{cookiecutter.package_name}}/theme.config
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/theme/assets/semantic-ui/less/{{cookiecutter.package_name}}/theme.config
@@ -46,7 +46,7 @@
 @form        : 'default';
 @grid        : 'default';
 @menu        : 'invenio';
-@message     : 'default';
+@message     : 'invenio';
 @table       : 'default';
 
 /* Modules */


### PR DESCRIPTION
Apply the message.overrides from `invenio-theme` to message component.
Fixes top margin for message.

Before:
![Screenshot 2020-12-10 at 13 11 13](https://user-images.githubusercontent.com/33685068/101770780-3e2f2480-3ae9-11eb-94a7-d1eecbbc0433.png)

After:
![Screenshot 2020-12-10 at 12 35 32](https://user-images.githubusercontent.com/33685068/101768776-4e91d000-3ae6-11eb-8734-4a4c9ae60675.png)
