### PR TITLE
Freeze invenio version to fix locking issues

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-invenio = { version = ">=3.4.0,<3.5.0", extras = ["base", "auth", "metadata", "files", "{{ cookiecutter.database }}", "elasticsearch{{ cookiecutter.elasticsearch }}" ]}
+invenio = { version = "~=3.5.0a3", extras = ["base", "auth", "metadata", "files", "{{ cookiecutter.database }}", "elasticsearch{{ cookiecutter.elasticsearch }}" ]}
 lxml = ">=4.3.0,<5.0.0"
 marshmallow = ">=3.0.0,<4.0.0"
 uwsgi = ">=2.0"


### PR DESCRIPTION
Fixed an issue where dependencies locking would be stuck forever (`pipenv lock --dev`), specifically when locking `invenio` version.

It is fixed using invenio's version `3.5.0a3` .