### PR TITLE
Add 'python_version' to cookiecutter config variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ To generate correct files, please provide the following input to Cookiecutter:
                               necessarily the same as the copyright holder.
 `author_email`                E-Mail address of the primary author.
 `year`                        Current year.
+`python_version`              Python version to be used by the instance.
 `copyright_holder`            Name of the person or organization who acts as the
                               copyright holder of this project.
 `transifex_project`           Name of the project on transifex translation platform.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
     "author_name": "CERN",
     "author_email": "info@{{ cookiecutter.project_site }}",
     "year": "{% now 'local', '%Y' %}",
+    "python_version": ["3.8", "3.9"],
     "copyright_holder": "{{ cookiecutter.author_name }}",
     "transifex_project": "{{ cookiecutter.project_shortname }}",
     "database": ["postgresql", "mysql"],

--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -11,6 +11,9 @@ uwsgi = ">=2.0"
 uwsgi-tools = ">=1.1.1"
 uwsgitop = ">=0.11"
 
+[requires]
+python_version = "{{ cookiecutter.python_version.split()[0] }}"
+
 [dev-packages]
 pytest-invenio = ">=1.4.1,<1.5.0"
 Sphinx = ">=3.0.0,<4"


### PR DESCRIPTION
### Description
This pull requests adds `python_version` config variable to cookiecutter.