### PR TITLE
Fix `update_record_files_async` signature

### DIFF
--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/tasks.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/records/tasks.py
@@ -28,8 +28,8 @@ def update_record_files_by_bucket(bucket_id):
             pass
 
 
-def update_record_files_async(object_version):
+def update_record_files_async(object_version, obj):
     """Get the bucket id and spawn a task to update record metadata."""
     # convert to string to be able to serialize it when sending to the task
-    str_uuid = str(object_version.bucket_id)
+    str_uuid = str(obj.bucket_id)
     return update_record_files_by_bucket.delay(bucket_id=str_uuid)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Trying to upload files [via the REST API](https://invenio-records-files.readthedocs.io/en/latest/usage.html#integration-with-invenio-rest-api) gives the following (abridged) error:

```
...
  File "example/venv/lib64/python3.10/site-packages/invenio_files_rest/views.py", line 625, in create_object
    file_uploaded.send(current_app._get_current_object(), obj=obj)
  File "example/venv/lib64/python3.10/site-packages/blinker/base.py", line 266, in send
    return [(receiver, receiver(sender, **kwargs))
  File "example/venv/lib64/python3.10/site-packages/blinker/base.py", line 266, in <listcomp>
    return [(receiver, receiver(sender, **kwargs))
TypeError: update_record_files_async() got an unexpected keyword argument 'obj'
```

From this, I gather that `update_records_files_async` requires two arguments, one of which is called `obj`. It currently takes one argument which is named `object_version`. With this change it seems to work at least. I'm not sure how to test it automatically though

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
